### PR TITLE
[DEVOPS-13393] Add timeout-minutes and concurrency to GitHub workflows

### DIFF
--- a/.github/workflows/main-to-qa-backmerge.yml
+++ b/.github/workflows/main-to-qa-backmerge.yml
@@ -3,6 +3,10 @@ on:
   pull_request:
     branches: [main]
     types: [closed]
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: false
+
 jobs:
   merge-main-back-to-qa:
     if: github.event.pull_request.merged == true && github.event.pull_request.head.ref != 'qa'


### PR DESCRIPTION
## Summary
Adds `timeout-minutes` and `concurrency` to GitHub Actions workflows as part of the GitHub Actions audit.

## Jira
[DEVOPS-13393](https://armorcodeinc.atlassian.net/browse/DEVOPS-13393)

[DEVOPS-13393]: https://armorcodeinc.atlassian.net/browse/DEVOPS-13393?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ