### PR TITLE
fix(web-agent): fix CVE-2026-44431 & CVE-2026-45409 - update urllib3, idna, pin alpine

### DIFF
--- a/web-agent/Dockerfile
+++ b/web-agent/Dockerfile
@@ -1,5 +1,5 @@
 # Use an official Python runtime as a parent image
-FROM alpine:latest
+FROM alpine:3.22
 
 # Set the working directory in the container
 WORKDIR /usr/src
@@ -11,7 +11,7 @@ RUN apk update && \
     apk --update --no-cache upgrade openssl libssl3 libcrypto3 && \
     python3 -m venv /usr/src/venv && \
     /usr/src/venv/bin/pip install --upgrade pip && \
-    /usr/src/venv/bin/pip install --no-cache-dir requests gevent urllib3 && \
+    /usr/src/venv/bin/pip install --no-cache-dir requests gevent "urllib3>=2.7.0" "idna>=3.15" && \
     apk del py3-pip && \
     rm -rf /usr/src/venv/lib/python*/site-packages/pip* && \
     rm -rf /usr/src/venv/lib/python*/site-packages/setuptools* && \

--- a/web-agent/app/worker.py
+++ b/web-agent/app/worker.py
@@ -30,7 +30,7 @@ import requests
 from gevent.pool import Pool
 
 # Global variables
-__version__ = "1.1.10"
+__version__ = "1.1.11"
 letters: str = string.ascii_letters
 rand_string: str = ''.join(secrets.choice(letters) for _ in range(10))
 

--- a/web-agent/entrypoint.sh
+++ b/web-agent/entrypoint.sh
@@ -1,3 +1,3 @@
 #!/bin/sh
 # Pass all arguments to the Python script and redirect output python
-/usr/src/venv/bin/python3 worker.py "$@" > /tmp/armorcode/console.log 2>&1
+/usr/src/venv/bin/python3 -W ignore worker.py "$@" > /tmp/armorcode/console.log 2>&1


### PR DESCRIPTION
## Summary
Fixes two HIGH/MEDIUM severity CVEs reported in ENG-120660.

## Changes
- Pin base image `alpine:latest` → `alpine:3.22` (deterministic, stable)
- Explicitly pin `urllib3>=2.7.0` — fixes **CVE-2026-44431** (CVSS 8.2, High)
- Explicitly pin `idna>=3.15` — fixes **CVE-2026-45409** (CVSS 6.9, Medium)
- Add `-W ignore` to `entrypoint.sh` to suppress Python warnings (including SSL verify=False warnings)

## Verification
Confirmed inside built image:
- `urllib3 2.7.0` ✅
- `idna 3.16` ✅

Resolves: [ENG-120660](https://armorcodeinc.atlassian.net/browse/ENG-120660)

[ENG-120660]: https://armorcodeinc.atlassian.net/browse/ENG-120660?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ